### PR TITLE
CHS misalignment warning

### DIFF
--- a/vblade.8
+++ b/vblade.8
@@ -77,8 +77,17 @@ background.
 nai:~# vblade 11 1 eth0 /data/3TB
 .fi
 .EE
-.SH BUGS
+.SH NOTES AND WARNINGS
 Users of Jumbo frames should read the README file distributed with
-vblade to learn about a workaround for kernel buffering limitations.
+.I vblade
+to learn about a workaround for kernel buffering limitations.
+.PP
+At least one AoE initiator (WinAoE) has been found to enforce legacy
+CHS geometry for drives by discarding sectors. You should ensure that
+the underlaying regular file or block device size is a multiple of
+8225280 bytes (255 heads, 63 sectors/track, 512 bytes/sector) if you
+encounter filesystem corruption.
+.SH REPORTING BUGS
+Please report bugs to the aoetools-discuss mailing list.
 .SH AUTHOR
 Brantley Coile (brantley@coraid.com)


### PR DESCRIPTION
WinAoE has some code in the GettingsSize state that truncates a disk to
CHS geometry. Prior to Vista, Windows enforced CHS alignment for
partition boundaries, so this was not a problem.
However, if you installed a newer OS (one using 1MB boundaries) then
moved it to AoE storage, truncating at a partition boundary could cause
sectors to be missing under WinAoE, corrupting your data. Windows
probably never actually relied on this behaviour, since it was enforcing
alignment itself.
This commit adds a warning regarding this to the man page.